### PR TITLE
Add debug statement to connection closing.

### DIFF
--- a/lib/puppet_x/puppetlabs/transport/ssh.rb
+++ b/lib/puppet_x/puppetlabs/transport/ssh.rb
@@ -38,6 +38,7 @@ module PuppetX::Puppetlabs::Transport
     end
 
     def close
+      Puppet.debug("#{self.class} closing connection to: #{@host}")
       @ssh.close if @ssh
     end
   end


### PR DESCRIPTION
Useful to detect when connection closed: "debug: Closing 
PuppetX::Puppetlabs::Transport::Ssh connection to: 192.168.232.147"
