### PR TITLE
Additional workaround for load_path.

### DIFF
--- a/lib/puppet/provider/vcsa.rb
+++ b/lib/puppet/provider/vcsa.rb
@@ -1,9 +1,20 @@
 # Copyright (C) 2013 VMware, Inc.
-require 'pathname' # WORK_AROUND #14073 and #7788
-module_lib = Pathname.new(__FILE__).parent.parent.parent
-vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
-require File.join vmware_module.path, 'lib/puppet_x/puppetlabs/transport'
-require File.join module_lib, 'puppet_x/puppetlabs/transport/ssh'
+begin
+  require 'puppet_x/puppetlabs/transport'
+rescue LoadError => detail
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  vmware_module = Puppet::Module.find('vmware_lib', Puppet[:environment].to_s)
+  require File.join vmware_module.path, 'lib/puppet_x/puppetlabs/transport'
+end
+
+begin
+  require 'puppet_x/puppetlabs/transport/ssh'
+rescue LoadError => detail
+  require 'pathname' # WORK_AROUND #14073 and #7788
+  module_lib = Pathname.new(__FILE__).parent.parent.parent
+  require File.join module_lib, 'puppet_x/puppetlabs/transport/ssh'
+end
+
 
 class Puppet::Provider::Vcsa <  Puppet::Provider
   confine :feature => :ssh


### PR DESCRIPTION
This is required for puppet agents and pluginsync to load the lib files from
vmware_lib.

Fix #8.
