### PR TITLE
Set transport option user_known_hosts_file to /dev/null

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,9 @@ define vcsa (
     username => $username,
     password => $password,
     server   => $server,
+    options  => {
+      'user_known_hosts_file' => '/dev/null',
+    },
   }
 
   vcsa_eula { $name:


### PR DESCRIPTION
If we redeploy vcsa appliance it will refuse ssh connection. In this case we
no longer want to store the user known hosts file.
