### PR TITLE
Exclude lines that don't match pattern of 'key=value' when creating Hash

### DIFF
--- a/lib/puppet/provider/vcsa.rb
+++ b/lib/puppet/provider/vcsa.rb
@@ -15,7 +15,7 @@ class Puppet::Provider::Vcsa <  Puppet::Provider
   include PuppetX::Puppetlabs::Transport
 
   def servicecfg_catch(result)
-    error = Hash[*result.split("\n").map{|x| x.split("=",2) if x =~ /^(?!Key not found)/ && x =~ /^(?!Stopping)/ }.compact.flatten]
+    error = Hash[*result.split("\n").map{|x| x.split("=",2) if x =~ /^(?!Key not found)/ && x =~ /^(?!Stopping)/ && x =~ /=/ }.compact.flatten]
     raise Puppet::Error, "vpxd_servicecfg failure: Returned #{result.sub(/\n/, ', ')}" if error['VC_CFG_RESULT'] != '0'
   end
 end

--- a/lib/puppet/provider/vcsa_db/default.rb
+++ b/lib/puppet/provider/vcsa_db/default.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:vcsa_db).provide(:ssh, :parent => Puppet::Provider::Vcsa ) do
 
   def exists?
     result = transport.exec!('vpxd_servicecfg db read')
-    result = Hash[*result.split("\n").collect{|x| x.split('=',2)}.flatten]
+    result = Hash[*result.split("\n").collect{|x| x.split('=',2) if x =~ /=/}.compact.flatten]
     result['VC_DB_TYPE'] != ''
   end
 end

--- a/lib/puppet/provider/vcsa_eula/default.rb
+++ b/lib/puppet/provider/vcsa_eula/default.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:vcsa_eula).provide(:ssh, :parent => Puppet::Provider::Vcsa ) 
 
   def exists?
     result = transport.exec!('vpxd_servicecfg eula read')
-    result = Hash[*result.split("\n").collect{|x| x.split('=')}.flatten]
+    result = Hash[*result.split("\n").collect{|x| x.split('=',2) if x =~ /=/}.compact.flatten]
     result['VC_EULA_STATUS'] != "0"
   end
 end

--- a/lib/puppet/provider/vcsa_java/default.rb
+++ b/lib/puppet/provider/vcsa_java/default.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:vcsa_java).provide(:ssh, :parent => Puppet::Provider::Vcsa ) 
   def exists?
     result = transport.exec!('vpxd_servicecfg jvm-max-heap read')
     # populating  @property_hash allows us to use mk_resource_methods
-    result = Hash[*result.split("\n").collect{|x| x.split('=',2)}.flatten]
+    result = Hash[*result.split("\n").collect{|x| x.split('=',2) if x =~ /=/}.compact.flatten]
 
     @property_hash[:tomcat]    = result['VC_MAX_HEAP_SIZE_TOMCAT']
     @property_hash[:inventory] = result['VC_MAX_HEAP_SIZE_QS']

--- a/lib/puppet/provider/vcsa_service/default.rb
+++ b/lib/puppet/provider/vcsa_service/default.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:vcsa_service).provide(:ssh, :parent => Puppet::Provider::Vcsa
 
   def exists?
     result = transport.exec!('vpxd_servicecfg service status')
-    result = Hash[*result.split("\n").collect{|x| x.split('=',2)}.flatten]
+    result = Hash[*result.split("\n").collect{|x| x.split('=',2) if x =~ /=/}.compact.flatten]
     result['VC_SERVICE_STATUS'] != '0'
   end
 end

--- a/lib/puppet/provider/vcsa_sso/default.rb
+++ b/lib/puppet/provider/vcsa_sso/default.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:vcsa_sso).provide(:ssh, :parent => Puppet::Provider::Vcsa ) d
   end
 
   def vpxd_servicecfg
-    @vpxd_servicecfg ||= Hash[*read.split("\n").map{|x| x.split("=",2) if x =~ /^(?!Key not found)/ }.compact.flatten]
+    @vpxd_servicecfg ||= Hash[*read.split("\n").map{|x| x.split("=",2) if x =~ /^(?!Key not found)/ && x =~ /=/ }.compact.flatten]
   end
 
   def command

--- a/lib/puppet/provider/vcsa_timesync/default.rb
+++ b/lib/puppet/provider/vcsa_timesync/default.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:vcsa_timesync).provide(:ssh, :parent => Puppet::Provider::Vcs
   end
 
   def vpxd_servicecfg
-    @vpxd_servicecfg ||= Hash[*read.split("\n").map{|x| x.split("=",2) if x =~ /^(?!Key not found)/ }.compact.flatten]
+    @vpxd_servicecfg ||= Hash[*read.split("\n").map{|x| x.split("=",2) if x =~ /^(?!Key not found)/ && x =~ /=/ }.compact.flatten]
   end
 
   def exists?


### PR DESCRIPTION
- Fix for the 'odd number of arguments for Hash' error that can occur during the vcsa init